### PR TITLE
Update bevy to 0.16.0-rc.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "crates-io.md"
 rust-version = "1.60"
 
 [dependencies]
-bevy_math = "0.15"
-bevy_transform = "0.15"
+bevy_math = "0.16.0-rc.3"
+bevy_transform = "^0.16.0-rc.3"
 #glam = ">=0.21, <=0.24"
 
 [dev-dependencies]


### PR DESCRIPTION
No api change, bevy_dolly is updated to the same version as dolly, need this to merge first.